### PR TITLE
Update Holden Commodore generations: Correct VZ end year and add references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# Model make
+# Holden Commodore
 
+This repository contains signal set configurations for the Holden Commodore, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Holden Commodore.
+
+The Holden Commodore was Holden's flagship model from 1978 to 2020, spanning six distinct platform generations and multiple series updates within each generation. Production occurred in Australia from 1978 to 2017, with the final imported ZB model sold until 2020. The Commodore established itself as an Australian automotive icon, competing directly with the Ford Falcon and serving as the backbone of Holden's vehicle lineup.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Holden_Commodore"
+
 generations:
   - name: "VB"
     start_year: 1978
@@ -16,7 +19,7 @@ generations:
 
   - name: "VT, VX, VY, VZ"
     start_year: 1997
-    end_year: 2006
+    end_year: 2007
     description: "The third-generation Commodore was based on the Opel Omega B platform but extensively modified for Australian requirements. The VT introduced more sophisticated styling, improved safety, and enhanced refinement. Engine options evolved to include an upgraded 3.8L V6 and later a Gen III 5.7L V8. The VX, VY, and VZ updates brought incremental improvements to styling, technology, and powertrains, with the VZ introducing the locally developed Alloytec V6. This generation expanded to include the Monaro coupe and all-wheel drive variants, demonstrating the platform's versatility. Throughout this period, the Commodore maintained its position as a cornerstone of Australian car culture and Holden's most important model."
 
   - name: "VE, VF"


### PR DESCRIPTION
- Changed VZ end_year from 2006 to 2007 per Wikipedia infobox showing VZ (2004–2007)
- Added references array with Wikipedia article URL
- Updated README.md to standard template

Wikipedia evidence:
- Infobox shows production from 1978–2017 (Australia), 2018–2020 (Germany)
- Third generation section: VZ (2004–2007) explicitly listed
